### PR TITLE
Replace most ToServer instances with a single overlappable instance

### DIFF
--- a/mig-extra/src/Mig/Extra/Server/Json.hs
+++ b/mig-extra/src/Mig/Extra/Server/Json.hs
@@ -21,7 +21,8 @@ module Mig.Extra.Server.Json (
 
   -- * re-exports
   module X,
-) where
+)
+where
 
 import Mig.Client (FromClient (..), ToClient (..))
 import Mig.Core (
@@ -55,11 +56,6 @@ instance (ToSchema a, FromJSON a, ToRoute b) => ToRoute (Body a -> b) where
 
   toRouteFun f =
     (toRouteFun :: ((Core.Body Json a -> b) -> ServerFun (Core.MonadOf b)))
-      (\(Core.Body a) -> f (Body a))
-
-instance (ToSchema a, FromJSON a, ToRoute b) => ToServer (Body a -> b) where
-  toServer f =
-    (toServer :: ((Core.Body Json a -> b) -> Server (Core.MonadOf b)))
       (\(Core.Body a) -> f (Body a))
 
 instance (FromJSON a, ToSchema a, ToPlugin b) => ToPlugin (Body a -> b) where


### PR DESCRIPTION
We can construct a server from every route. However this requires `UndecidableInstances` and a `OVERLAPPABLE` pragma.

Not sure if this is actually better, but it does mean we have to don´t have to define extra instances for the `ToServer` class.

I will just leave this here. Feel free to close it if you don´t like it.