### PR TITLE
Simplify `renderServer` for `ReaderT` and `ExceptT`

### DIFF
--- a/examples/mig-example-apps/Counter/Main.hs
+++ b/examples/mig-example-apps/Counter/Main.hs
@@ -21,7 +21,7 @@ main :: IO ()
 main = do
   env <- initEnv
   putStrLn ("The counter server listens on port: " <> show port)
-  runServer port . withSwagger def =<< (renderServer server env)
+  runServer port . withSwagger def $ renderServer server env
   where
     port = 8085
 


### PR DESCRIPTION
Hoisting the server monad does not require IO.

I am also not sure whether we actually need the `HasServer` class. By exporting `hositServer` it is trivial for users to use any custom monad and then hoist to `IO` to run the server.